### PR TITLE
Add an heroku command to accommodate to new heroku stack setting

### DIFF
--- a/getting_set_up.md
+++ b/getting_set_up.md
@@ -39,6 +39,7 @@ Then from within your copy of the Typo repository, run:
 
 ```
 $ heroku create
+$ heroku apps:stacks:set cedar-14
 $ git push heroku master
 $ heroku run rake db:migrate
 $ heroku open # doesn't work on C9 --> on C9 right click on link that git push to heroku generates


### PR DESCRIPTION
Heroku default stack now is set to heroku-16, on which Ruby 1.9.3 is not available. We need to specify cedar-14 for our app to use to be able to install Ruby 1.9.3 while deploying to Heroku.